### PR TITLE
Update runtime to 22.08

### DIFF
--- a/io.github.paulwedeck.settlers-remake.yaml
+++ b/io.github.paulwedeck.settlers-remake.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.paulwedeck.settlers-remake
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: jsettlers
 sdk-extensions:


### PR DESCRIPTION
OpenJDK 11 is available for the new runtime since yesterday.